### PR TITLE
Set update_cache to yes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
   ansible.builtin.package:
     name: "{{ core_dependencies }}"
     state: present
+    update_cache: yes
   notify:
     - gather facts
 


### PR DESCRIPTION
On newly provisioned ubuntu 20.04 machines, this task fails unless the apt cache is updated.

Here is the failure log -

TASK [robertdebock.core_dependencies : install packages] **************************************************************************************
fatal: [3.110.51.146]: FAILED! => {"changed": false, "msg": "No package matching 'subversion' is available"}

---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
A clear and concise description of what the pull request is.

**Testing**
In case a feature was added, how were tests performed?
